### PR TITLE
#16 #17 #18 #19 Salvage join lobby UX from stale PR 26

### DIFF
--- a/app/session/join/page.tsx
+++ b/app/session/join/page.tsx
@@ -1,97 +1,308 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Alert, Button, Card, Input, Space, Spin, Typography } from "antd";
 import { useApi } from "@/hooks/useApi";
 import { GameSession } from "@/types/session";
-import { Button, Card, Input, Space, Typography } from "antd";
 
 const { Title, Text } = Typography;
 
-export default function JoinSessionPage() {
+const normalizeSessionCode = (value: string) =>
+  value.toUpperCase().replace(/[^A-Z0-9]/g, "").slice(0, 6);
+
+const formatErrorMessage = (error: unknown, fallback: string) =>
+  error instanceof Error ? error.message : fallback;
+
+function getStoredUserId() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const rawId = localStorage.getItem("id");
+  if (!rawId) {
+    return null;
+  }
+
+  const parsedId = JSON.parse(rawId);
+  const userId = Number(parsedId);
+  return Number.isFinite(userId) ? userId : null;
+}
+
+function isExpired(session: GameSession) {
+  const expiresAt = Date.parse(session.expiresAt);
+  return Number.isFinite(expiresAt) && expiresAt <= Date.now();
+}
+
+function getStatusLabel(status?: GameSession["status"]) {
+  switch (status) {
+    case "ACTIVE":
+      return "Active";
+    case "CANCELLED":
+      return "Cancelled";
+    default:
+      return "Waiting";
+  }
+}
+
+function JoinSessionPageContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const apiService = useApi();
-  const [code, setCode] = useState("");
-  const [loading, setLoading] = useState(false);
+  const queryCode = normalizeSessionCode(searchParams.get("code") ?? "");
+
+  const [code, setCode] = useState(queryCode);
+  const [session, setSession] = useState<GameSession | null>(null);
+  const [loadingSession, setLoadingSession] = useState(Boolean(queryCode));
+  const [joining, setJoining] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const handleSessionState = (updatedSession: GameSession) => {
+    if (updatedSession.status === "ACTIVE") {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+      }
+      router.push(`/play_test?code=${updatedSession.code}`);
+      return;
+    }
+
+    if (updatedSession.status === "CANCELLED" || isExpired(updatedSession)) {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+      }
+      router.push("/menu");
+    }
+  };
+
+  useEffect(() => {
+    setCode(queryCode);
+
+    if (!queryCode) {
+      setSession(null);
+      setError(null);
+      setLoadingSession(false);
+      return;
+    }
+
+    const loadSession = async () => {
+      setLoadingSession(true);
+      setError(null);
+
+      try {
+        const loadedSession = await apiService.get<GameSession>(`/sessions/${queryCode}`);
+        setSession(loadedSession);
+        handleSessionState(loadedSession);
+      } catch (err) {
+        setSession(null);
+        setError(formatErrorMessage(err, "Failed to load session."));
+      } finally {
+        setLoadingSession(false);
+      }
+    };
+
+    void loadSession();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [queryCode, apiService]);
+
+  useEffect(() => {
+    if (!session?.code) {
+      return;
+    }
+
+    const pollSession = async () => {
+      try {
+        const updatedSession = await apiService.get<GameSession>(`/sessions/${session.code}`);
+        setSession(updatedSession);
+        handleSessionState(updatedSession);
+      } catch {
+        if (pollRef.current) {
+          clearInterval(pollRef.current);
+        }
+        router.push("/menu");
+      }
+    };
+
+    pollRef.current = setInterval(pollSession, 3000);
+    return () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+      }
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session?.code, apiService, router]);
 
   const handleJoin = async () => {
-    const rawId = typeof window !== "undefined" ? localStorage.getItem("id") : null;
-    const userId = rawId ? Number(JSON.parse(rawId)) : null;
+    const userId = getStoredUserId();
 
     if (!userId) {
       router.push("/login");
       return;
     }
 
-    const trimmedCode = code.trim().toUpperCase();
-    if (!trimmedCode) {
-      setError("Please enter a session code.");
+    const trimmedCode = normalizeSessionCode(code);
+    if (trimmedCode.length !== 6) {
+      setError("Please enter a valid 6-character session code.");
       return;
     }
 
-    setLoading(true);
+    setJoining(true);
     setError(null);
 
     try {
-      await apiService.post<GameSession>(`/sessions/${trimmedCode}/join`, {
-        userId,
-      });
-      router.push(`/session/waiting?code=${trimmedCode}`);
+      const joinedSession = await apiService.post<GameSession>(
+        `/sessions/${trimmedCode}/join`,
+        { userId },
+      );
+      setSession(joinedSession);
+      router.replace(`/session/join?code=${trimmedCode}`);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to join session.");
+      setSession(null);
+      setError(formatErrorMessage(err, "Failed to join session."));
     } finally {
-      setLoading(false);
+      setJoining(false);
     }
   };
 
-  return (
-    <div style={{ display: "flex", justifyContent: "center", alignItems: "center", height: "100vh", background: "#0a0a0a" }}>
-      <Card
-        style={{
-          width: 420,
-          background: "#1a1a2e",
-          border: "1px solid #16213e",
-          borderRadius: 16,
-        }}
-      >
-        <Space direction="vertical" size="large" style={{ width: "100%" }}>
-          <Title level={2} style={{ color: "#e0e0e0", textAlign: "center", margin: 0 }}>
-            Join Session
-          </Title>
+  if (loadingSession) {
+    return (
+      <div className="session-simple-shell">
+        <Card className="session-simple-card">
+          <Space direction="vertical" size="middle" align="center" style={{ width: "100%" }}>
+            <Spin size="large" />
+            <Text className="session-simple-subtitle">Loading session...</Text>
+          </Space>
+        </Card>
+      </div>
+    );
+  }
 
-          <div>
-            <Text style={{ color: "#aaa", fontSize: 13, display: "block", marginBottom: 8 }}>
-              Enter the 6-character session code:
+  if (session) {
+    const playerCount = session.players?.length ?? 0;
+
+    return (
+      <div className="session-simple-shell">
+        <Card className="session-simple-card">
+          <Space direction="vertical" size="large" style={{ width: "100%" }}>
+            <div>
+              <Title level={2} className="session-simple-title">
+                Joined Session
+              </Title>
+              <Text className="session-simple-subtitle">
+                Waiting for the host to start the game.
+              </Text>
+            </div>
+
+            <div className="session-simple-code-box">
+              <Text className="session-simple-label">Session Code</Text>
+              <div className="session-simple-code">{session.code}</div>
+            </div>
+
+            <div className="session-simple-info-list">
+              <div className="session-simple-info-row">
+                <Text className="session-simple-info-label">Status</Text>
+                <Text className="session-simple-info-value">{getStatusLabel(session.status)}</Text>
+              </div>
+              <div className="session-simple-info-row">
+                <Text className="session-simple-info-label">Players</Text>
+                <Text className="session-simple-info-value">{playerCount}/2</Text>
+              </div>
+            </div>
+
+            <div className="session-simple-section">
+              <Text className="session-simple-section-title">Players</Text>
+              <Space direction="vertical" size="small" style={{ width: "100%" }}>
+                {session.players?.map((player, idx) => (
+                  <div key={`${player}-${idx}`} className="session-simple-player-row">
+                    <Text className="session-simple-player-role">
+                      {idx === 0 ? "Host" : "Player 2"}
+                    </Text>
+                    <Text className="session-simple-player-name">{player}</Text>
+                  </div>
+                ))}
+                {playerCount < 2 && (
+                  <div className="session-simple-player-row">
+                    <Text className="session-simple-player-role">Open</Text>
+                    <Text className="session-simple-player-name session-simple-player-name-muted">
+                      Waiting for player 2
+                    </Text>
+                  </div>
+                )}
+              </Space>
+            </div>
+
+            <Text className="session-simple-status-note">
+              Only the host can start the game.
             </Text>
+
+            <Space direction="vertical" style={{ width: "100%" }} size="middle">
+              <Button
+                type="primary"
+                size="large"
+                className="session-simple-primary-button"
+                disabled
+              >
+                Only the host can start
+              </Button>
+              <Button
+                size="large"
+                className="session-simple-secondary-button"
+                onClick={() => router.push("/menu")}
+              >
+                Back to Menu
+              </Button>
+            </Space>
+          </Space>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="session-simple-shell">
+      <Card className="session-simple-card">
+        <Space direction="vertical" size="large" style={{ width: "100%" }}>
+          <div>
+            <Title level={2} className="session-simple-title">
+              Join Session
+            </Title>
+            <Text className="session-simple-subtitle">
+              Enter the session code to join your friend&apos;s lobby.
+            </Text>
+          </div>
+
+          <Space direction="vertical" size="small" style={{ width: "100%" }}>
+            <Text className="session-simple-label">Session Code</Text>
             <Input
               value={code}
-              onChange={(e) => setCode(e.target.value.toUpperCase())}
+              onChange={(event) => {
+                setCode(normalizeSessionCode(event.target.value));
+                setError(null);
+              }}
               onPressEnter={handleJoin}
               maxLength={6}
-              placeholder="e.g. ABC123"
+              placeholder="ABC123"
+              size="large"
+              autoComplete="off"
               style={{
                 background: "#16213e",
-                border: "1px solid #333",
-                color: "#e0e0e0",
+                border: "1px solid #30456f",
+                color: "#fff",
                 fontSize: 24,
                 textAlign: "center",
                 letterSpacing: 8,
-                fontFamily: "monospace",
+                fontFamily: "var(--font-geist-mono), monospace",
                 height: 56,
               }}
             />
-          </div>
+          </Space>
 
-          {error && (
-            <Text type="danger" style={{ fontSize: 13 }}>
-              {error}
-            </Text>
-          )}
+          {error && <Alert message={error} type="error" showIcon />}
 
           <Space style={{ width: "100%" }} size="middle">
             <Button
               size="large"
+              className="session-simple-secondary-button"
               style={{ flex: 1 }}
               onClick={() => router.push("/menu")}
             >
@@ -100,9 +311,10 @@ export default function JoinSessionPage() {
             <Button
               type="primary"
               size="large"
+              className="session-simple-primary-button"
               style={{ flex: 1 }}
-              loading={loading}
-              disabled={code.trim().length !== 6}
+              loading={joining}
+              disabled={code.length !== 6}
               onClick={handleJoin}
             >
               Join
@@ -111,5 +323,26 @@ export default function JoinSessionPage() {
         </Space>
       </Card>
     </div>
+  );
+}
+
+function JoinSessionFallback() {
+  return (
+    <div className="session-simple-shell">
+      <Card className="session-simple-card">
+        <Space direction="vertical" size="middle" align="center" style={{ width: "100%" }}>
+          <Spin size="large" />
+          <Text className="session-simple-subtitle">Loading session...</Text>
+        </Space>
+      </Card>
+    </div>
+  );
+}
+
+export default function JoinSessionPage() {
+  return (
+    <Suspense fallback={<JoinSessionFallback />}>
+      <JoinSessionPageContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- Salvages the useful join-lobby UX from stale PR #26 into a clean branch from current `origin/main`.
- Keeps the change scoped to `app/session/join/page.tsx`.
- Intentionally leaves stale `contributions.md`, duplicate menu changes, `/session/waiting`, and unrelated gameplay files untouched.

## Behavior
- `/session/join` still shows the code-entry form.
- `/session/join?code=ABC123` loads the session lobby directly when the session exists.
- Successful join stays on `/session/join?code=...` and renders the joined lobby inline.
- Invalid join/load errors are shown inline.
- Joiner lobby shows session code, status, players, and a disabled host-only start action.
- Polling redirects to `/play_test?code=...` when the host starts and exits to `/menu` if the session is cancelled, expired, or unreadable.

## Validation
- `pnpm build` passes.
- Existing warnings remain in `app/play_test/page.tsx` for unused `scoreUi`/`lifeUi` and hook dependencies; this PR does not touch that file.