### PR TITLE
Fix & finalize gameplay

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -39,8 +39,8 @@ const Login: React.FC = () => {
 
   return (
     <div className="login-container">
-<div className="login-card">
-        <h1 className="login-title">Login</h1>
+      <div className="login-card">
+        <h1 className="login-title">Math Invaders</h1>
       <Form
         form={form}
         name="login"
@@ -64,8 +64,13 @@ const Login: React.FC = () => {
           <Input.Password placeholder="Enter password" />
         </Form.Item>
         <Form.Item>
-          <Button type="primary" htmlType="submit" className="login-button">
+          <Button type="primary" htmlType="submit" className="login-button" block>
             Login
+          </Button>
+        </Form.Item>
+        <Form.Item style={{ marginBottom: 0, textAlign: "center" }}>
+          <Button type="link" onClick={() => router.push("/register")} style={{ padding: 0 }}>
+            No account? Register here
           </Button>
         </Form.Item>
       </Form>

--- a/app/menu/page.tsx
+++ b/app/menu/page.tsx
@@ -14,10 +14,10 @@ export default function MenuPage() {
         <Space direction="vertical" size="large" style={{ width: "100%" }}>
           <div>
             <Title level={2} className="menu-title">
-              Main Menu
+              Math Invaders
             </Title>
             <Text className="menu-subtitle">
-              Choose an action to continue.
+              Play solo or team up with a friend.
             </Text>
           </div>
 
@@ -26,18 +26,9 @@ export default function MenuPage() {
               type="primary"
               variant="solid"
               className="menu-button"
-              onClick={() => router.push("/profile")}
-            >
-              User Profile
-            </Button>
-
-            <Button
-              type="primary"
-              variant="solid"
-              className="menu-button"
               onClick={() => router.push("/session/create")}
             >
-              Create Session
+              Create Multiplayer Session
             </Button>
 
             <Button
@@ -55,8 +46,16 @@ export default function MenuPage() {
               className="menu-button"
               onClick={() => router.push("/play_test")}
             >
-              Play Test
+              Solo Practice
+            </Button>
 
+            <Button
+              type="default"
+              variant="solid"
+              className="menu-button"
+              onClick={() => router.push("/profile")}
+            >
+              My Profile
             </Button>
 
             <Button

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,124 +1,20 @@
-"use client"; // For components that need React hooks and browser APIs, SSR (server side rendering) has to be disabled. Read more here: https://nextjs.org/docs/pages/building-your-application/rendering/server-side-rendering
+"use client";
+
+import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import Image from "next/image";
-import { Button } from "antd";
-import { BookOutlined, CodeOutlined, GlobalOutlined } from "@ant-design/icons";
-import styles from "@/styles/page.module.css";
 
 export default function Home() {
   const router = useRouter();
-  return (
-    <div className={styles.page}>
-      <main className={styles.main}>
-        <h1>Math Invaders — Group 42</h1>
-        <Image
-          className={styles.logo}
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol>
-          <li>
-            <code>app/page.tsx</code>{" "}
-            is the landing page for your application, currently being displayed.
-          </li>
-          <li>
-            <code>app/login/page.tsx</code> is the login page for users.
-          </li>
-          <li>
-            <code>app/users/page.tsx</code>{" "}
-            is the dashboard that shows an overview of all users, fetched from
-            the server.
-          </li>
-          <li>
-            <code>app/users/[id]/page.tsx</code>{" "}
-            is a slug page that shows info of a particular user. Since each user
-            has its own id, each user has its own infopage, dynamically with the
-            use of slugs.
-          </li>
-          <li>
-            To test, modify the current page <code>app/page.tsx</code>{" "}
-            and save to see your changes instantly.
-          </li>
-        </ol>
 
-        <div className={styles.ctas}>
-          <Button
-            type="primary" // as defined in the ConfigProvider in [layout.tsx](./layout.tsx), all primary antd elements are colored #22426b, with buttons #75bd9d as override
-            color="red" // if a single/specific antd component needs yet a different color, it can be explicitly overridden in the component as shown here
-            variant="solid" // read more about the antd button and its options here: https://ant.design/components/button
-            onClick={() =>
-              globalThis.open(
-                "https://vercel.com/new",
-                "_blank",
-                "noopener,noreferrer",
-              )}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Deploy now
-          </Button>
-          <Button
-            type="default"
-            variant="solid"
-            onClick={() =>
-              globalThis.open(
-                "https://nextjs.org/docs",
-                "_blank",
-                "noopener,noreferrer",
-              )}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </Button>
-          <Button
-            type="primary"
-            variant="solid"
-            onClick={() => router.push("/login")}
-          >
-            Go to login
-          </Button>
-          <Button
-            type="primary"
-            variant="solid"
-            onClick={() => router.push("/register")}
-          >
-            Register
-          </Button>
-        </div>
-      </main>
-      <footer className={styles.footer}>
-        <Button
-          type="link"
-          icon={<BookOutlined />}
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn
-        </Button>
-        <Button
-          type="link"
-          icon={<CodeOutlined />}
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Examples
-        </Button>
-        <Button
-          type="link"
-          icon={<GlobalOutlined />}
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Go to nextjs.org →
-        </Button>
-      </footer>
-    </div>
-  );
+  useEffect(() => {
+    const token = typeof window !== "undefined" ? localStorage.getItem("token") : null;
+    const id = typeof window !== "undefined" ? localStorage.getItem("id") : null;
+    if (token && id) {
+      router.replace("/menu");
+    } else {
+      router.replace("/login");
+    }
+  }, [router]);
+
+  return null;
 }

--- a/app/play_test/page.tsx
+++ b/app/play_test/page.tsx
@@ -21,7 +21,7 @@ const SHIP_MOVE_SPEED = 420;
 const FALLING_BLOCK_SPEED = 21;
 const SESSION_FETCH_RETRIES = 3;
 const SESSION_PROBLEM_POLL_LIMIT = 45;
-const SESSION_PROBLEM_POLL_INTERVAL_MS = 2000;
+const SESSION_PROBLEM_POLL_INTERVAL_MS = 400;
 const INITIAL_LIFE = 3;
 const INCORRECT_FLASH_MS = 1000;
 
@@ -50,7 +50,7 @@ const BLOCK_STYLE = {
 // Realtime and API payload types
 type RealtimeMessage =
 |{
-  type: "move" | "shoot";
+  type: "move" | "shoot" | "play_again_ready";
   playerId: number;
   x: number;
   y: number;
@@ -274,6 +274,13 @@ function PlayTestContent() {
   const isGameFinishedRef = useRef(false);
   const finishRequestStartedRef = useRef(false);
 
+  // Play-again ready gate (both players must click before restarting)
+  const isLocalCreatorRef = useRef(true);
+  const localPlayAgainReadyRef = useRef(false);
+  const remotePlayAgainReadyPlayersRef = useRef<Set<number>>(new Set());
+  const [playAgainReadyCount, setPlayAgainReadyCount] = useState(0);
+  const lastMoveSendRef = useRef(0);
+
   const scheduleIncorrectReset = useCallback((blockId: number) => {
     const existingTimeout = incorrectResetTimeoutsRef.current.get(blockId);
     if (existingTimeout) {
@@ -376,6 +383,18 @@ function PlayTestContent() {
       blocksRef.current = nextBlocks;
       selectedBlockIdsRef.current = new Set(data.selectedBlockIds ?? []);
       syncPairProgressFromBlocks();
+      return;
+    }
+
+    if (data.type === "play_again_ready" && typeof data.playerId === "number") {
+      if (data.playerId !== localShipRef.current.playerId) {
+        remotePlayAgainReadyPlayersRef.current.add(data.playerId);
+        const total = (localPlayAgainReadyRef.current ? 1 : 0) + remotePlayAgainReadyPlayersRef.current.size;
+        setPlayAgainReadyCount(total);
+        if (total >= 2) {
+          window.location.reload();
+        }
+      }
       return;
     }
 
@@ -485,6 +504,26 @@ function PlayTestContent() {
 
   // WebSocket integration
   const { sendMessage } = useWebSocket(handleMessage);
+
+  const handlePlayAgainReady = useCallback(() => {
+    if (!code) {
+      window.location.reload();
+      return;
+    }
+    if (localPlayAgainReadyRef.current) return;
+    localPlayAgainReadyRef.current = true;
+    const total = 1 + remotePlayAgainReadyPlayersRef.current.size;
+    setPlayAgainReadyCount(total);
+    sendMessage("/app/move", {
+      type: "play_again_ready",
+      playerId: localShipRef.current.playerId,
+      x: 0,
+      y: 0,
+    });
+    if (total >= 2) {
+      window.location.reload();
+    }
+  }, [code, sendMessage]);
 
   useEffect(() => {
     timerSourceMsRef.current = timerSourceMs;
@@ -628,11 +667,13 @@ function PlayTestContent() {
     const configureAsCreator = (currentUserId: number) => {
       localShipRef.current.playerId = currentUserId;
       remoteShipRef.current.playerId = -1;
+      isLocalCreatorRef.current = true;
     };
 
     const configureAsJoiner = (currentUserId: number, creatorId: number) => {
       localShipRef.current.playerId = currentUserId;
       remoteShipRef.current.playerId = creatorId;
+      isLocalCreatorRef.current = false;
     };
 
     const fetchSessionWithRetry = async () => {
@@ -1069,12 +1110,16 @@ function PlayTestContent() {
       }
 
       if (moved) {
-        sendMessage("/app/move", {
-          type: "move",
-          playerId: localShipRef.current.playerId,
-          x: localShipRef.current.xPosition,
-          y: localShipRef.current.yPosition,
-        });
+        const nowMs = performance.now();
+        if (nowMs - lastMoveSendRef.current > 50) {
+          lastMoveSendRef.current = nowMs;
+          sendMessage("/app/move", {
+            type: "move",
+            playerId: localShipRef.current.playerId,
+            x: localShipRef.current.xPosition,
+            y: localShipRef.current.yPosition,
+          });
+        }
       }
 
       const lerp = 1 - Math.exp(-12 * deltaSeconds);
@@ -1106,8 +1151,8 @@ function PlayTestContent() {
         drawBlock(block);
       }
 
-      drawShip(localShipRef.current, "red");
-      drawShip(remoteShipRef.current, "cyan");
+      drawShip(localShipRef.current, isLocalCreatorRef.current ? "#ff4d4f" : "#3d85ff");
+      drawShip(remoteShipRef.current, isLocalCreatorRef.current ? "#3d85ff" : "#ff4d4f");
 
       const nextBullets: BulletObject[] = [];
       bulletsRef.current = bulletsRef.current.filter((bullet) => !bullet.isOffScreen());
@@ -1320,6 +1365,28 @@ function PlayTestContent() {
           visibility: isLoadingProblems ? "hidden" : "visible",
         }}
       >
+        {!isGameFinished && !isPenaltyGameOver && (
+          <button
+            type="button"
+            onClick={() => { window.location.href = "/menu"; }}
+            style={{
+              position: "absolute",
+              top: 10,
+              left: 10,
+              zIndex: 5,
+              padding: "6px 14px",
+              backgroundColor: "rgba(0,0,0,0.55)",
+              color: "#aaa",
+              border: "1px solid #444",
+              borderRadius: 8,
+              cursor: "pointer",
+              fontWeight: 600,
+              fontSize: 13,
+            }}
+          >
+            ← Menu
+          </button>
+        )}
         <canvas
           ref={canvasRef}
           width={CANVAS_WIDTH}
@@ -1387,24 +1454,48 @@ function PlayTestContent() {
               >
                 {formatElapsedTime(finalElapsedSeconds ?? displayedElapsedSeconds)}
               </div>
-              <button
-                type="button"
-                onClick={() => {
-                  window.location.href = "/menu";
-                }}
-                style={{
-                  padding: "12px 18px",
-                  border: "none",
-                  borderRadius: 10,
-                  backgroundColor: "#00d4ff",
-                  color: "#031019",
-                  fontWeight: 800,
-                  cursor: "pointer",
-                  minWidth: 140,
-                }}
-              >
-                Leave Game
-              </button>
+              <div style={{ display: "flex", justifyContent: "center", gap: 12, flexWrap: "wrap" }}>
+                <button
+                  type="button"
+                  onClick={handlePlayAgainReady}
+                  disabled={localPlayAgainReadyRef.current}
+                  style={{
+                    padding: "12px 18px",
+                    border: "none",
+                    borderRadius: 10,
+                    backgroundColor: localPlayAgainReadyRef.current ? "#0a8fa8" : "#00d4ff",
+                    color: "#031019",
+                    fontWeight: 800,
+                    cursor: localPlayAgainReadyRef.current ? "default" : "pointer",
+                    minWidth: 160,
+                    opacity: localPlayAgainReadyRef.current ? 0.7 : 1,
+                  }}
+                >
+                  {code
+                    ? localPlayAgainReadyRef.current
+                      ? `Ready ${playAgainReadyCount}/2`
+                      : "Play Again"
+                    : "Play Again"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    window.location.href = "/menu";
+                  }}
+                  style={{
+                    padding: "12px 18px",
+                    border: "1px solid #1f6f8b",
+                    borderRadius: 10,
+                    backgroundColor: "#08131f",
+                    color: "#e8f7ff",
+                    fontWeight: 800,
+                    cursor: "pointer",
+                    minWidth: 140,
+                  }}
+                >
+                  Leave Game
+                </button>
+              </div>
             </div>
           </div>
         )}
@@ -1451,24 +1542,30 @@ function PlayTestContent() {
               <div style={{ display: "flex", justifyContent: "center", gap: 12, flexWrap: "wrap" }}>
                 <button
                   type="button"
-                  onClick={() => window.location.reload()}
+                  onClick={handlePlayAgainReady}
+                  disabled={localPlayAgainReadyRef.current}
                   style={{
                     padding: "12px 18px",
                     border: "none",
                     borderRadius: 10,
-                    backgroundColor: "#ff4d4f",
+                    backgroundColor: localPlayAgainReadyRef.current ? "#7f2122" : "#ff4d4f",
                     color: "#fff5f5",
                     fontWeight: 800,
-                    cursor: "pointer",
-                    minWidth: 140,
+                    cursor: localPlayAgainReadyRef.current ? "default" : "pointer",
+                    minWidth: 160,
+                    opacity: localPlayAgainReadyRef.current ? 0.7 : 1,
                   }}
                 >
-                  Play Again
+                  {code
+                    ? localPlayAgainReadyRef.current
+                      ? `Ready ${playAgainReadyCount}/2`
+                      : "Play Again"
+                    : "Play Again"}
                 </button>
                 <button
                   type="button"
                   onClick={() => {
-                    window.location.href = code ? `/session/waiting?code=${code}` : "/menu";
+                    window.location.href = "/menu";
                   }}
                   style={{
                     padding: "12px 18px",

--- a/app/play_test/page.tsx
+++ b/app/play_test/page.tsx
@@ -653,16 +653,22 @@ function PlayTestContent() {
     }
   }, [code, sendMessage]);
 
-  // Send game_ready_ack once problems are applied and sendMessage is available
+  // Keep broadcasting game_ready_ack until the game starts.
+  // A single send can be missed if the partner subscribed after we sent it,
+  // so we retry every 500 ms until isLoadingProblems flips to false.
   useEffect(() => {
-    if (!problemsSentAck || !code) return;
-    sendMessage("/app/move", {
-      type: "game_ready_ack",
-      playerId: localShipRef.current.playerId,
-      x: 0,
-      y: 0,
-    });
-  }, [problemsSentAck, code, sendMessage]);
+    if (!problemsSentAck || !code || !isLoadingProblems) return;
+    const send = () =>
+      sendMessage("/app/move", {
+        type: "game_ready_ack",
+        playerId: localShipRef.current.playerId,
+        x: 0,
+        y: 0,
+      });
+    send();
+    const interval = setInterval(send, 500);
+    return () => clearInterval(interval);
+  }, [problemsSentAck, code, sendMessage, isLoadingProblems]);
 
   useEffect(() => {
     timerSourceMsRef.current = timerSourceMs;

--- a/app/play_test/page.tsx
+++ b/app/play_test/page.tsx
@@ -50,10 +50,18 @@ const BLOCK_STYLE = {
 // Realtime and API payload types
 type RealtimeMessage =
 |{
-  type: "move" | "shoot" | "play_again_ready";
+  type: "move" | "shoot" | "play_again_ready" | "pause" | "resume" | "slow_on" | "slow_off";
   playerId: number;
   x: number;
   y: number;
+}
+|{
+  type: "pair_advance";
+  playerId: number;
+  x: number;
+  y: number;
+  pairIndex: number;
+  levelIndex: number;
 }
 |{
   type: "game_state";
@@ -281,6 +289,12 @@ function PlayTestContent() {
   const [playAgainReadyCount, setPlayAgainReadyCount] = useState(0);
   const lastMoveSendRef = useRef(0);
 
+  // Pause and slow-mode
+  const isPausedRef = useRef(false);
+  const [isPaused, setIsPaused] = useState(false);
+  const isSlowModeRef = useRef(false);
+  const [isSlowMode, setIsSlowMode] = useState(false);
+
   const scheduleIncorrectReset = useCallback((blockId: number) => {
     const existingTimeout = incorrectResetTimeoutsRef.current.get(blockId);
     if (existingTimeout) {
@@ -304,11 +318,21 @@ function PlayTestContent() {
       return;
     }
 
-    const completedPairs = Math.floor(
-      blocksRef.current.filter((block) => block.state === GameBlockState.ELIMINATED).length / 2,
-    );
+    // Count eliminated blocks per pair index (id = pairIndex*2 + offset)
+    const elimCountByPair = new Map<number, number>();
+    for (const block of blocksRef.current) {
+      if (block.state === GameBlockState.ELIMINATED) {
+        const pairIdx = Math.floor(block.id / 2);
+        elimCountByPair.set(pairIdx, (elimCountByPair.get(pairIdx) ?? 0) + 1);
+      }
+    }
 
-    if (completedPairs >= currentProblem.pairs.length) {
+    const completedPairSet = new Set<number>();
+    for (const [pairIdx, count] of elimCountByPair) {
+      if (count >= 2) completedPairSet.add(pairIdx);
+    }
+
+    if (completedPairSet.size >= currentProblem.pairs.length) {
       const nextLevel = currentLevelRef.current + 1;
       if (nextLevel < problemsRef.current.length) {
         currentLevelRef.current = nextLevel;
@@ -319,7 +343,13 @@ function PlayTestContent() {
       return;
     }
 
-    currentPairIndexRef.current = Math.max(currentPairIndexRef.current, completedPairs);
+    // Advance to the first pair that is not yet completed
+    for (let i = 0; i < currentProblem.pairs.length; i++) {
+      if (!completedPairSet.has(i)) {
+        currentPairIndexRef.current = i;
+        return;
+      }
+    }
   }, []);
 
   // Realtime message handler
@@ -394,6 +424,44 @@ function PlayTestContent() {
         if (total >= 2) {
           window.location.reload();
         }
+      }
+      return;
+    }
+
+    if (data.type === "pause") {
+      isPausedRef.current = true;
+      setIsPaused(true);
+      return;
+    }
+
+    if (data.type === "resume") {
+      isPausedRef.current = false;
+      setIsPaused(false);
+      return;
+    }
+
+    if (data.type === "slow_on") {
+      isSlowModeRef.current = true;
+      setIsSlowMode(true);
+      return;
+    }
+
+    if (data.type === "slow_off") {
+      isSlowModeRef.current = false;
+      setIsSlowMode(false);
+      return;
+    }
+
+    if (data.type === "pair_advance" && typeof (data as { pairIndex?: number }).pairIndex === "number") {
+      const msg = data as { pairIndex: number; levelIndex: number };
+      if (msg.levelIndex === currentLevelRef.current) {
+        currentPairIndexRef.current = msg.pairIndex;
+        selectedBlockIdsRef.current.clear();
+      } else if (msg.levelIndex > currentLevelRef.current && msg.levelIndex < problemsRef.current.length) {
+        currentLevelRef.current = msg.levelIndex;
+        currentPairIndexRef.current = msg.pairIndex;
+        selectedBlockIdsRef.current.clear();
+        blocksRef.current = buildBlocks(problemsRef.current[msg.levelIndex]);
       }
       return;
     }
@@ -522,6 +590,24 @@ function PlayTestContent() {
     });
     if (total >= 2) {
       window.location.reload();
+    }
+  }, [code, sendMessage]);
+
+  const handlePauseToggle = useCallback(() => {
+    const next = !isPausedRef.current;
+    isPausedRef.current = next;
+    setIsPaused(next);
+    if (code) {
+      sendMessage("/app/move", { type: next ? "pause" : "resume", playerId: localShipRef.current.playerId, x: 0, y: 0 });
+    }
+  }, [code, sendMessage]);
+
+  const handleSlowToggle = useCallback(() => {
+    const next = !isSlowModeRef.current;
+    isSlowModeRef.current = next;
+    setIsSlowMode(next);
+    if (code) {
+      sendMessage("/app/move", { type: next ? "slow_on" : "slow_off", playerId: localShipRef.current.playerId, x: 0, y: 0 });
     }
   }, [code, sendMessage]);
 
@@ -978,10 +1064,24 @@ function PlayTestContent() {
       ctx.fillText(`Points: ${scoreRef.current}`, CANVAS_WIDTH - 12, 36);
     };
 
+    const broadcastPairAdvance = (pairIndex: number, levelIndex: number) => {
+      if (!code) return;
+      sendMessage("/app/move", {
+        type: "pair_advance",
+        playerId: localShipRef.current.playerId,
+        x: 0,
+        y: 0,
+        pairIndex,
+        levelIndex,
+      });
+    };
+
     const advancePair = () => {
       selectedBlockIdsRef.current.clear();
+      const currentProblem = problemsRef.current[currentLevelRef.current];
+      const pairCount = currentProblem?.pairs.length ?? 5;
       const nextPair = currentPairIndexRef.current + 1;
-      if (nextPair >= 5) {
+      if (nextPair >= pairCount) {
         const nextLevel = currentLevelRef.current + 1;
 
         if (nextLevel >= problemsRef.current.length) {
@@ -991,10 +1091,12 @@ function PlayTestContent() {
         currentLevelRef.current = nextLevel;
         currentPairIndexRef.current = 0;
         blocksRef.current = buildBlocks(problemsRef.current[nextLevel]);
+        broadcastPairAdvance(0, nextLevel);
         return false;
       }
 
       currentPairIndexRef.current = nextPair;
+      broadcastPairAdvance(nextPair, currentLevelRef.current);
 
       for (const block of blocksRef.current) {
         if (block.state === GameBlockState.SELECTED) {
@@ -1086,6 +1188,11 @@ function PlayTestContent() {
         return;
       }
 
+      if (isPausedRef.current) {
+        lastTimestamp = null;
+        return;
+      }
+
       if (lastTimestamp === null) {
         lastTimestamp = timestamp;
         return;
@@ -1122,7 +1229,7 @@ function PlayTestContent() {
         }
       }
 
-      const lerp = 1 - Math.exp(-12 * deltaSeconds);
+      const lerp = 1 - Math.exp(-18 * deltaSeconds);
       remoteShipRef.current.xPosition +=
         (remoteTargetRef.current.x - remoteShipRef.current.xPosition) * lerp;
       remoteShipRef.current.yPosition +=
@@ -1136,7 +1243,7 @@ function PlayTestContent() {
           return false;
         }
 
-        block.yPosition += FALLING_BLOCK_SPEED * deltaSeconds;
+        block.yPosition += (isSlowModeRef.current ? FALLING_BLOCK_SPEED * 0.35 : FALLING_BLOCK_SPEED) * deltaSeconds;
 
         if (block.yPosition >= groundLimit) {
           selectedBlockIdsRef.current.delete(block.id);
@@ -1207,7 +1314,17 @@ function PlayTestContent() {
     animationId = requestAnimationFrame(gameLoop);
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (gameOverRef.current || penaltyGameOverRef.current || isGameFinishedRef.current) {
+      if (event.code === "KeyP") {
+        const next = !isPausedRef.current;
+        isPausedRef.current = next;
+        setIsPaused(next);
+        if (code) {
+          sendMessage("/app/move", { type: next ? "pause" : "resume", playerId: localShipRef.current.playerId, x: 0, y: 0 });
+        }
+        return;
+      }
+
+      if (gameOverRef.current || penaltyGameOverRef.current || isGameFinishedRef.current || isPausedRef.current) {
         return;
       }
 
@@ -1235,12 +1352,26 @@ function PlayTestContent() {
     };
 
     const handleKeyUp = (event: KeyboardEvent) => {
+      const wasLeft = pressedKeysRef.current.left;
+      const wasRight = pressedKeysRef.current.right;
+
       if (event.code === "KeyA" || event.code === "ArrowLeft") {
         pressedKeysRef.current.left = false;
       }
 
       if (event.code === "KeyD" || event.code === "ArrowRight") {
         pressedKeysRef.current.right = false;
+      }
+
+      // Send final position when player stops so remote snaps to correct spot
+      if ((wasLeft || wasRight) && !pressedKeysRef.current.left && !pressedKeysRef.current.right) {
+        sendMessage("/app/move", {
+          type: "move",
+          playerId: localShipRef.current.playerId,
+          x: localShipRef.current.xPosition,
+          y: localShipRef.current.yPosition,
+        });
+        lastMoveSendRef.current = performance.now();
       }
     };
 
@@ -1366,26 +1497,119 @@ function PlayTestContent() {
         }}
       >
         {!isGameFinished && !isPenaltyGameOver && (
-          <button
-            type="button"
-            onClick={() => { window.location.href = "/menu"; }}
+          <>
+            <button
+              type="button"
+              onClick={() => { window.location.href = "/menu"; }}
+              style={{
+                position: "absolute",
+                top: 10,
+                left: 10,
+                zIndex: 5,
+                padding: "6px 14px",
+                backgroundColor: "rgba(0,0,0,0.55)",
+                color: "#aaa",
+                border: "1px solid #444",
+                borderRadius: 8,
+                cursor: "pointer",
+                fontWeight: 600,
+                fontSize: 13,
+              }}
+            >
+              ← Menu
+            </button>
+            <div style={{ position: "absolute", top: 10, right: 10, zIndex: 5, display: "flex", gap: 8 }}>
+              <button
+                type="button"
+                onClick={handleSlowToggle}
+                title="Toggle slow mode (blocks fall slower)"
+                style={{
+                  padding: "6px 14px",
+                  backgroundColor: isSlowMode ? "#7c4dff" : "rgba(0,0,0,0.55)",
+                  color: isSlowMode ? "#fff" : "#aaa",
+                  border: `1px solid ${isSlowMode ? "#7c4dff" : "#444"}`,
+                  borderRadius: 8,
+                  cursor: "pointer",
+                  fontWeight: 600,
+                  fontSize: 13,
+                }}
+              >
+                {isSlowMode ? "🐢 Slow ON" : "🐢 Slow"}
+              </button>
+              <button
+                type="button"
+                onClick={handlePauseToggle}
+                title="Pause / Resume (P)"
+                style={{
+                  padding: "6px 14px",
+                  backgroundColor: isPaused ? "#ff9800" : "rgba(0,0,0,0.55)",
+                  color: isPaused ? "#000" : "#aaa",
+                  border: `1px solid ${isPaused ? "#ff9800" : "#444"}`,
+                  borderRadius: 8,
+                  cursor: "pointer",
+                  fontWeight: 600,
+                  fontSize: 13,
+                }}
+              >
+                {isPaused ? "▶ Resume" : "⏸ Pause"}
+              </button>
+            </div>
+          </>
+        )}
+
+        {isPaused && !isGameFinished && !isPenaltyGameOver && (
+          <div
             style={{
               position: "absolute",
-              top: 10,
-              left: 10,
-              zIndex: 5,
-              padding: "6px 14px",
-              backgroundColor: "rgba(0,0,0,0.55)",
-              color: "#aaa",
-              border: "1px solid #444",
-              borderRadius: 8,
-              cursor: "pointer",
-              fontWeight: 600,
-              fontSize: 13,
+              inset: 0,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              backgroundColor: "rgba(0,0,0,0.72)",
+              zIndex: 15,
+              gap: 20,
             }}
           >
-            ← Menu
-          </button>
+            <div style={{ color: "#ff9800", fontFamily: "monospace", fontSize: 36, fontWeight: 900, letterSpacing: 4 }}>
+              PAUSED
+            </div>
+            <div style={{ color: "#888", fontSize: 14 }}>Press P or click Resume to continue</div>
+            <div style={{ display: "flex", gap: 12 }}>
+              <button
+                type="button"
+                onClick={handlePauseToggle}
+                style={{
+                  padding: "12px 28px",
+                  backgroundColor: "#ff9800",
+                  color: "#000",
+                  border: "none",
+                  borderRadius: 10,
+                  cursor: "pointer",
+                  fontWeight: 800,
+                  fontSize: 16,
+                }}
+              >
+                ▶ Resume
+              </button>
+              <button
+                type="button"
+                onClick={() => { window.location.href = "/menu"; }}
+                style={{
+                  padding: "12px 28px",
+                  backgroundColor: "rgba(255,255,255,0.08)",
+                  color: "#ccc",
+                  border: "1px solid #555",
+                  borderRadius: 10,
+                  cursor: "pointer",
+                  fontWeight: 700,
+                  fontSize: 16,
+                }}
+              >
+                ← Menu
+              </button>
+            </div>
+          </div>
         )}
         <canvas
           ref={canvasRef}

--- a/app/play_test/page.tsx
+++ b/app/play_test/page.tsx
@@ -50,7 +50,7 @@ const BLOCK_STYLE = {
 // Realtime and API payload types
 type RealtimeMessage =
 |{
-  type: "move" | "shoot" | "play_again_ready" | "pause" | "resume" | "slow_on" | "slow_off";
+  type: "move" | "shoot" | "play_again_ready" | "pause" | "resume" | "slow_on" | "slow_off" | "game_ready_ack";
   playerId: number;
   x: number;
   y: number;
@@ -289,11 +289,28 @@ function PlayTestContent() {
   const [playAgainReadyCount, setPlayAgainReadyCount] = useState(0);
   const lastMoveSendRef = useRef(0);
 
-  // Pause and slow-mode
+  // Pause and slow-mode (slow-mode persists in localStorage across play-again reloads)
   const isPausedRef = useRef(false);
   const [isPaused, setIsPaused] = useState(false);
   const isSlowModeRef = useRef(false);
   const [isSlowMode, setIsSlowMode] = useState(false);
+
+  // Eliminated block IDs — persists even after blocks are filtered from blocksRef
+  const eliminatedBlockIdsRef = useRef<Set<number>>(new Set());
+
+  // Multiplayer game-start handshake: wait for both players to confirm problems loaded
+  const gameReadyPlayersRef = useRef<Set<number>>(new Set());
+  const problemsAppliedRef = useRef(false);
+  const [problemsSentAck, setProblemsSentAck] = useState(false);
+
+  // Restore slow mode from previous session
+  useEffect(() => {
+    const stored = localStorage.getItem("mi_slow_mode") === "1";
+    if (stored) {
+      isSlowModeRef.current = true;
+      setIsSlowMode(true);
+    }
+  }, []);
 
   const scheduleIncorrectReset = useCallback((blockId: number) => {
     const existingTimeout = incorrectResetTimeoutsRef.current.get(blockId);
@@ -318,13 +335,12 @@ function PlayTestContent() {
       return;
     }
 
-    // Count eliminated blocks per pair index (id = pairIndex*2 + offset)
+    // Use the persistent eliminatedBlockIdsRef — blocks may already be filtered
+    // out of blocksRef.current by the game loop before this runs.
     const elimCountByPair = new Map<number, number>();
-    for (const block of blocksRef.current) {
-      if (block.state === GameBlockState.ELIMINATED) {
-        const pairIdx = Math.floor(block.id / 2);
-        elimCountByPair.set(pairIdx, (elimCountByPair.get(pairIdx) ?? 0) + 1);
-      }
+    for (const blockId of eliminatedBlockIdsRef.current) {
+      const pairIdx = Math.floor(blockId / 2);
+      elimCountByPair.set(pairIdx, (elimCountByPair.get(pairIdx) ?? 0) + 1);
     }
 
     const completedPairSet = new Set<number>();
@@ -338,6 +354,7 @@ function PlayTestContent() {
         currentLevelRef.current = nextLevel;
         currentPairIndexRef.current = 0;
         selectedBlockIdsRef.current.clear();
+        eliminatedBlockIdsRef.current.clear();
         blocksRef.current = buildBlocks(problemsRef.current[nextLevel]);
       }
       return;
@@ -400,6 +417,7 @@ function PlayTestContent() {
             break;
           case "ELIMINATED":
             existingBlock.state = GameBlockState.ELIMINATED;
+            eliminatedBlockIdsRef.current.add(existingBlock.id);
             break;
           case "INCORRECT":
             existingBlock.state = GameBlockState.INCORRECT;
@@ -428,31 +446,42 @@ function PlayTestContent() {
       return;
     }
 
-    if (data.type === "pause") {
+    // All control messages below are ignored when echoed back from self
+    const isFromSelf = typeof data.playerId === "number" && data.playerId === localShipRef.current.playerId;
+
+    if (data.type === "game_ready_ack" && typeof data.playerId === "number") {
+      gameReadyPlayersRef.current.add(data.playerId);
+      if (gameReadyPlayersRef.current.size >= 2 && problemsAppliedRef.current) {
+        setIsLoadingProblems(false);
+      }
+      return;
+    }
+
+    if (data.type === "pause" && !isFromSelf) {
       isPausedRef.current = true;
       setIsPaused(true);
       return;
     }
 
-    if (data.type === "resume") {
+    if (data.type === "resume" && !isFromSelf) {
       isPausedRef.current = false;
       setIsPaused(false);
       return;
     }
 
-    if (data.type === "slow_on") {
+    if (data.type === "slow_on" && !isFromSelf) {
       isSlowModeRef.current = true;
       setIsSlowMode(true);
       return;
     }
 
-    if (data.type === "slow_off") {
+    if (data.type === "slow_off" && !isFromSelf) {
       isSlowModeRef.current = false;
       setIsSlowMode(false);
       return;
     }
 
-    if (data.type === "pair_advance" && typeof (data as { pairIndex?: number }).pairIndex === "number") {
+    if (data.type === "pair_advance" && !isFromSelf && typeof (data as { pairIndex?: number }).pairIndex === "number") {
       const msg = data as { pairIndex: number; levelIndex: number };
       if (msg.levelIndex === currentLevelRef.current) {
         currentPairIndexRef.current = msg.pairIndex;
@@ -461,6 +490,7 @@ function PlayTestContent() {
         currentLevelRef.current = msg.levelIndex;
         currentPairIndexRef.current = msg.pairIndex;
         selectedBlockIdsRef.current.clear();
+        eliminatedBlockIdsRef.current.clear();
         blocksRef.current = buildBlocks(problemsRef.current[msg.levelIndex]);
       }
       return;
@@ -552,6 +582,7 @@ function PlayTestContent() {
     currentLevelRef.current = 0;
     currentPairIndexRef.current = 0;
     selectedBlockIdsRef.current.clear();
+    eliminatedBlockIdsRef.current.clear();
     blocksRef.current = buildBlocks(problems[0]);
 
     resetRoundStats();
@@ -561,12 +592,21 @@ function PlayTestContent() {
     incorrectResetTimeoutsRef.current.clear();
 
     setLoadingError(null);
-    setIsLoadingProblems(false);
+    problemsAppliedRef.current = true;
 
-    if (!code && timerSourceMsRef.current === null) {
-      const startedAtMs = Date.now();
-      timerSourceMsRef.current = startedAtMs;
-      setTimerSourceMs(startedAtMs);
+    if (!code) {
+      // Solo: start immediately
+      setIsLoadingProblems(false);
+      if (timerSourceMsRef.current === null) {
+        const startedAtMs = Date.now();
+        timerSourceMsRef.current = startedAtMs;
+        setTimerSourceMs(startedAtMs);
+      }
+    } else {
+      // Multiplayer: wait for both players to confirm they're ready
+      setLoadingStatus("Ready! Waiting for partner...");
+      gameReadyPlayersRef.current.clear();
+      setProblemsSentAck(true);
     }
   }, [code, resetRoundStats]);
 
@@ -606,10 +646,22 @@ function PlayTestContent() {
     const next = !isSlowModeRef.current;
     isSlowModeRef.current = next;
     setIsSlowMode(next);
+    localStorage.setItem("mi_slow_mode", next ? "1" : "0");
     if (code) {
       sendMessage("/app/move", { type: next ? "slow_on" : "slow_off", playerId: localShipRef.current.playerId, x: 0, y: 0 });
     }
   }, [code, sendMessage]);
+
+  // Send game_ready_ack once problems are applied and sendMessage is available
+  useEffect(() => {
+    if (!problemsSentAck || !code) return;
+    sendMessage("/app/move", {
+      type: "game_ready_ack",
+      playerId: localShipRef.current.playerId,
+      x: 0,
+      y: 0,
+    });
+  }, [problemsSentAck, code, sendMessage]);
 
   useEffect(() => {
     timerSourceMsRef.current = timerSourceMs;
@@ -1090,6 +1142,7 @@ function PlayTestContent() {
 
         currentLevelRef.current = nextLevel;
         currentPairIndexRef.current = 0;
+        eliminatedBlockIdsRef.current.clear();
         blocksRef.current = buildBlocks(problemsRef.current[nextLevel]);
         broadcastPairAdvance(0, nextLevel);
         return false;
@@ -1159,6 +1212,7 @@ function PlayTestContent() {
       if (selectedProduct === targetPair.product) {
         for (const selectedBlock of nextSelectedBlocks) {
           selectedBlock.eliminate();
+          eliminatedBlockIdsRef.current.add(selectedBlock.id);
         }
 
         increaseScore();

--- a/app/play_test/page.tsx
+++ b/app/play_test/page.tsx
@@ -603,9 +603,10 @@ function PlayTestContent() {
         setTimerSourceMs(startedAtMs);
       }
     } else {
-      // Multiplayer: wait for both players to confirm they're ready
+      // Multiplayer: wait for both players to confirm they're ready.
+      // Do NOT clear gameReadyPlayersRef — the partner's ack may have
+      // already arrived before our own applyProblems ran.
       setLoadingStatus("Ready! Waiting for partner...");
-      gameReadyPlayersRef.current.clear();
       setProblemsSentAck(true);
     }
   }, [code, resetRoundStats]);

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -57,17 +57,16 @@ export default function ProfilePage() {
       <Card className="profile-card">
         <Space direction="vertical" size="large" style={{ width: "100%" }}>
           <div className="profile-header">
+            <button
+              type="button"
+              onClick={() => router.push("/menu")}
+              style={{ background: "none", border: "none", color: "#aaa", cursor: "pointer", fontSize: 14, padding: "0 0 4px 0", alignSelf: "flex-start" }}
+            >
+              ← Back to Menu
+            </button>
             <Title level={2} className="profile-title">
               User Profile
             </Title>
-
-            <Button
-              type="text"
-              className="profile-close-button"
-              onClick={() => router.push("/menu")}
-            >
-              X
-            </Button>
           </div>
 
           {loading && <Spin size="large" />}

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -40,8 +40,8 @@ const Register: React.FC = () => {
 
   return (
     <div className="register-container">
-<div className="register-card">
-        <h1 className="register-title">Register</h1>
+      <div className="register-card">
+        <h1 className="register-title">Create Account</h1>
         {error && <Alert message="Registration Error" description={error} type="error" showIcon style={{ marginBottom: "20px" }} />}
       <Form
         form={form}
@@ -88,6 +88,11 @@ const Register: React.FC = () => {
         <Form.Item>
           <Button type="primary" htmlType="submit" className="register-button" block>
             Register
+          </Button>
+        </Form.Item>
+        <Form.Item style={{ marginBottom: 0, textAlign: "center" }}>
+          <Button type="link" onClick={() => router.push("/login")} style={{ padding: 0 }}>
+            Already have an account? Login
           </Button>
         </Form.Item>
       </Form>

--- a/app/session/create/page.tsx
+++ b/app/session/create/page.tsx
@@ -197,6 +197,13 @@ export default function CreateSessionPage() {
       <Card className="session-simple-card">
         <Space direction="vertical" size="large" style={{ width: "100%" }}>
           <div>
+            <button
+              type="button"
+              onClick={handleCancel}
+              style={{ background: "none", border: "none", color: "#aaa", cursor: "pointer", fontSize: 14, padding: "0 0 8px 0" }}
+            >
+              ← Back to Menu
+            </button>
             <Title level={2} className="session-simple-title">
               Create Session
             </Title>

--- a/app/session/join/page.tsx
+++ b/app/session/join/page.tsx
@@ -180,6 +180,13 @@ function JoinSessionPageContent() {
         <Card className="session-simple-card">
           <Space direction="vertical" size="large" style={{ width: "100%" }}>
             <div>
+              <button
+                type="button"
+                onClick={() => router.push("/menu")}
+                style={{ background: "none", border: "none", color: "#aaa", cursor: "pointer", fontSize: 14, padding: "0 0 8px 0" }}
+              >
+                ← Back to Menu
+              </button>
               <Title level={2} className="session-simple-title">
                 Joined Session
               </Title>

--- a/app/session/waiting/page.tsx
+++ b/app/session/waiting/page.tsx
@@ -100,6 +100,13 @@ function WaitingSessionPageContent() {
       <Card className="session-simple-card">
         <Space direction="vertical" size="large" style={{ width: "100%" }}>
           <div>
+            <button
+              type="button"
+              onClick={handleLeave}
+              style={{ background: "none", border: "none", color: "#aaa", cursor: "pointer", fontSize: 14, padding: "0 0 8px 0" }}
+            >
+              ← Back to Menu
+            </button>
             <Title level={2} className="session-simple-title">
               Waiting for Host
             </Title>

--- a/app/utils/mathProblems.ts
+++ b/app/utils/mathProblems.ts
@@ -2,7 +2,7 @@ import { MathBlock, MathPair, MathProblem } from "@/types/problem";
 
 export const PROBLEM_PAIR_COUNT = 5;
 export const BLOCK_COUNT_PER_LEVEL = PROBLEM_PAIR_COUNT * 2;
-export const DEFAULT_LEVEL_COUNT = 100;
+export const DEFAULT_LEVEL_COUNT = 10;
 
 const MIN_FACTOR = 1;
 const MAX_FACTOR = 12;


### PR DESCRIPTION
## Summary
- Fix endless "Ready! Waiting for partner..." loop by retrying `game_ready_ack` every 500ms until game starts (handles late WebSocket subscribers)
- Fix `gameReadyPlayersRef.clear()` wiping partner's already-received ack
- Fix multiplayer block tracking (eliminated blocks, synchronized game start)
- Add pause (P key + button) and slow-mode features
- Fix player colors (creator = red, joiner = blue)
- Fix 30-second loading time (reduced from 100 levels to 10)
- Improve navigation (back arrows everywhere, uniform UX)
- Performance: WebSocket move throttling, faster remote ship lerp

## Test plan
- [ ] Two players can connect and both see game start without getting stuck on the ready screen
- [ ] Pause/resume works for both players
- [ ] Slow mode persists and syncs between players
- [ ] Blocks no longer show impossible targets after factors are eliminated
- [ ] Play Again requires both players to click Ready